### PR TITLE
Remove $wpdb->prepare() on queries;

### DIFF
--- a/includes/class-wp-session-utils.php
+++ b/includes/class-wp-session-utils.php
@@ -72,12 +72,7 @@ class WP_Session_Utils {
 		global $wpdb;
 
 		$limit = absint( $limit );
-		$keys = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE '_wp_session_expires_%' ORDER BY option_value ASC LIMIT 0, %d",
-				$limit
-			)
-		);
+		$keys = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE '_wp_session_expires_%' ORDER BY option_value ASC LIMIT 0, {$limit}" );
 
 		$now = time();
 		$expired = array();
@@ -99,12 +94,8 @@ class WP_Session_Utils {
 
 		// Delete expired sessions
 		if ( ! empty( $expired ) ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM $wpdb->options WHERE option_name IN ('%s')",
-					implode( "','", $expired )
-				)
-			);
+			$names = implode( "','", $expired );
+			$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name IN ('{$names}')" );
 		}
 
 		return $count;


### PR DESCRIPTION
$wpdb->prepare() returns null on these queries when in place. Which
causes array errors and expired sessions to linger.
